### PR TITLE
Add implementation for JVM_IsContainerized

### DIFF
--- a/src/JvmFuncs.c
+++ b/src/JvmFuncs.c
@@ -382,6 +382,10 @@ int jio_vsnprintf(char *str, size_t count, const char *fmt, va_list args) {
   return result;
 }
 
+JNIEXPORT jboolean JVM_IsContainerized(void *env, void * ignored) {
+    return JNI_FALSE;
+}
+
 #if 0
 #ifdef JNI_VERSION_9
 /*


### PR DESCRIPTION
Add implementation for JVM_IsContainerized which is needed after JDK-8261242
JDK builds that contain 0a6ffa57954ddf4f92205205a5a1bada813d127a invoke JVM_isContainerized, hence the VM needs to provide thsi.